### PR TITLE
Fix for failing conditions on the setting the readOnlyRootFilesystem: true

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -89,8 +89,10 @@ To test your changes you can launch the operator locally. You need a running kub
 
 By default the operator produces logs in a JSON format. For easier reading during debugging you can switch the logging framework into a special development mode that switches off JSON and produces more details (stacktraces on warnings). Simply set the environment variable `OPERATOR_DEV_LOGGING=true` before running. E.g. to run locally with make: `OPERATOR_DEV_LOGGING=true make run`. If you want to enable this mode for a deployed operator use the `manager.extraEnv` helm chart values option to set the environment variable.
 
-Note that for some features the operator expects to be able to communicate directly with opensearch. This is not possible when the operator is running outside of kubernetes. In these cases you will need to deploy the operator to test it. Follow these steps:
-
+Note that for some features the operator expects to be able to communicate directly with opensearch. This could be achieved in 2 ways:
+1) Add Opensearch cluster DNS to your hosts file, e.g. `/etc/hosts`. Point it to localhost address.
+   E.g. `127.0.0.1 opensearch-primary.opensearch.svc.cluster.local`. Then port-forward `9200` and `9300` ports from kubernetes to your local env.
+2) Deploy the operator to remote cluster to test it. Follow these steps:
 * Run `make docker-build` to build the docker image
 * If needed import the image into your cluster (for k3d run `k3d image import controller:latest`)
 * Deploy the operator with helm by running `helm install opensearch-operator ../charts/opensearch-operator --set manager.image.repository=controller --set manager.image.tag=latest --set manager.image.pullPolicy=IfNotPresent`

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -756,7 +756,7 @@ spec:
       path: /path/to/mount/volume
       projected:
         sources:
-          serviceAccountToken:
+        - serviceAccountToken:
             path: "token"
   dashboards:
     additionalVolumes:

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -420,11 +420,13 @@ func NewSTSForNodePool(
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				/usr/share/opensearch/bin/opensearch-keystore create
+				if [ ! -f /usr/share/opensearch/config/opensearch.keystore ]; then
+				  /usr/share/opensearch/bin/opensearch-keystore create
+				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i"
+				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
@@ -935,11 +937,13 @@ func NewBootstrapPod(
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				/usr/share/opensearch/bin/opensearch-keystore create
+				if [ ! -f /usr/share/opensearch/config/opensearch.keystore ]; then
+				  /usr/share/opensearch/bin/opensearch-keystore create
+				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i"
+				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup

--- a/opensearch-operator/pkg/reconcilers/ismpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy.go
@@ -163,7 +163,7 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 		}, retErr
 	}
 
-	// If PolicyID is not provided explicitly, use metadata.name by default
+	// If PolicyId is not provided explicitly, use metadata.name by default
 	policyId = r.instance.Name
 	if r.instance.Spec.PolicyID != "" {
 		policyId = r.instance.Spec.PolicyID
@@ -251,8 +251,8 @@ func (r *IsmPolicyReconciler) Reconcile() (retResult ctrl.Result, retErr error) 
 	}
 
 	// Return if there are no changes
-	if r.instance.Spec.PolicyID == existingPolicy.PolicyID && cmp.Equal(*newPolicy, existingPolicy.Policy, cmpopts.EquateEmpty()) {
-		r.logger.V(1).Info(fmt.Sprintf("user %s is in sync", r.instance.Name))
+	if r.instance.Status.PolicyId == existingPolicy.PolicyID && cmp.Equal(*newPolicy, existingPolicy.Policy, cmpopts.EquateEmpty()) {
+		r.logger.V(1).Info(fmt.Sprintf("policy %s is in sync", r.instance.Name))
 		r.recorder.Event(r.instance, "Normal", opensearchAPIUnchanged, "policy is in sync")
 		return ctrl.Result{
 			Requeue:      true,
@@ -579,7 +579,7 @@ func (r *IsmPolicyReconciler) Delete() error {
 		return err
 	}
 
-	// If PolicyID not provided explicitly, use metadata.name by default
+	// If PolicyId not provided explicitly, use metadata.name by default
 	policyId := r.instance.Spec.PolicyID
 	if policyId == "" {
 		policyId = r.instance.Name

--- a/opensearch-operator/pkg/reconcilers/ismpolicy_test.go
+++ b/opensearch-operator/pkg/reconcilers/ismpolicy_test.go
@@ -38,7 +38,6 @@ var _ = Describe("ism policy reconciler", func() {
 		transport = httpmock.NewMockTransport()
 		transport.RegisterNoResponder(httpmock.NewNotFoundResponder(failMessage))
 		instance = &opsterv1.OpenSearchISMPolicy{
-
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-policy",
 				Namespace: "test-policy",
@@ -49,6 +48,9 @@ var _ = Describe("ism policy reconciler", func() {
 				OpensearchRef: corev1.LocalObjectReference{
 					Name: "test-cluster",
 				},
+			},
+			Status: opsterv1.OpensearchISMPolicyStatus{
+				PolicyId: "test-policy",
 			},
 		}
 
@@ -260,6 +262,7 @@ var _ = Describe("ism policy reconciler", func() {
 		Context("policy exists in opensearch", func() {
 			BeforeEach(func() {
 				instance.Spec.PolicyID = "test-policy-id"
+				instance.Status.PolicyId = "test-policy-id"
 
 				transport.RegisterResponder(
 					http.MethodGet,


### PR DESCRIPTION
# Description
The fix makes changes to add read-write locations for:
- `/usr/share/opensearch/conf`
- `/usr/share/opensearch/logs`
- `/usr/share/opensearch/plugins` (if `pluginsList` is specified)

## Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/951

## Check List
- [x] Commits are signed per the DCO using `--signoff`
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

## If CRDs are changed: No changes
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented